### PR TITLE
Truncate alone will trigger constraint errors on tables with foreign key

### DIFF
--- a/src/StefanoTree/Adapter/DbTraversal.php
+++ b/src/StefanoTree/Adapter/DbTraversal.php
@@ -808,7 +808,9 @@ class DbTraversal
             $transaction->begin();
             $dbLock->lockTables($this->getTableName());
             
+            $dbAdapter->query('SET FOREIGN_KEY_CHECKS=0;', DbAdapter::QUERY_MODE_EXECUTE);
             $dbAdapter->query('TRUNCATE '. $this->getTableName(), DbAdapter::QUERY_MODE_EXECUTE);
+            $dbAdapter->query('SET FOREIGN_KEY_CHECKS=1;', DbAdapter::QUERY_MODE_EXECUTE);
             
             $insert = new Db\Sql\Insert();
             $insert->into($this->getTableName())


### PR DESCRIPTION
Only valid for MySQL, other DB's require further investigation. Could use DELETE statement, but it's slow.
