### PR TITLE
Check the `left` property in order to check if a node is root or not

### DIFF
--- a/src/StefanoTree/NestedSet/NodeInfo.php
+++ b/src/StefanoTree/NestedSet/NodeInfo.php
@@ -108,7 +108,7 @@ class NodeInfo
      */
     public function isRoot(): bool
     {
-        if (0 == $this->getParentId()) {
+        if (1 === $this->getLeft()) {
             return true;
         } else {
             return false;


### PR DESCRIPTION

In order to be able to use `id` (and so `parentId`) as string I would like
to check the `left` property to discover if a node is root, because 0 ==
'an-id-string' is true in php.
Also the parentId can be null.